### PR TITLE
投稿者名をクリックして詳細ページへ遷移

### DIFF
--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -20,7 +20,7 @@
               <%= link_to prototype.name, prototype_path(prototype) %>
             </h2>
              <p class="card__summary"><%= prototype.catch_copy %></p>
-            <p class="card__user">by: <%= prototype.user.username %></p>
+            <p class="card__user">by: <%= link_to prototype.user.username,user_path(prototype.user) %></p>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
#what 
一覧ページの投稿者名から詳細ページに遷移するリンクの作成

#why
一覧ページの投稿者名から詳細ページに遷移する機能の実装